### PR TITLE
Append team release-management_reviewers as codeowners of /CHANGELOG.MD

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,7 @@
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins
 /MAINTAINERS.MD @camaraproject/admins
+
+# The following line ensures that the release-management_reviewers team will automatically added as reviewers
+# if a pull requests is changing the CHANGELOG.MD (aka "release PR") and that such PRs can only be merged with an approval from a team member.
+/CHANGELOG.MD @camaraproject /release-management_reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,4 +14,4 @@
 
 # The following line ensures that the release-management_reviewers team will automatically added as reviewers
 # if a pull requests is changing the CHANGELOG.MD (aka "release PR") and that such PRs can only be merged with an approval from a team member.
-/CHANGELOG.MD @camaraproject /release-management_reviewers
+/CHANGELOG.MD @camaraproject/release-management_reviewers


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* subproject management

#### What this PR does / why we need it:

Add a line to CODEOWNERS that ensures that the release-management_reviewers team will automatically added as reviewers
# if a pull requests is changing the CHANGELOG.MD (aka "release PR") and that such PRs can only be merged with an approval from a team

Note: this change will be introduced to all repositories, see https://github.com/camaraproject/ReleaseManagement/issues/195 for more details

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # none

#### Special notes for reviewers:

Change done here manually as there is the open PR #53 which will get a patch release PR.
